### PR TITLE
GitHub Actions で Docker イメージをビルドし GitHub Container Registry にアップロードする

### DIFF
--- a/.github/workflows/build-push-docker-image.yaml
+++ b/.github/workflows/build-push-docker-image.yaml
@@ -1,0 +1,104 @@
+name: Build and push Docker image to ghcr.io
+
+on:
+  push:
+  workflow_dispatch:
+
+env:
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            matrix.qemu: false
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            matrix.qemu: false
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Set platform pair name
+        run: |
+          platform=${{ matrix.platform }}
+          echo "PLATFORM_PAIR=${platform//\//-}" >> $GITHUB_ENV
+
+      - uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ github.ref_name }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        if: ${{ matrix.qemu }}
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: ${{ matrix.platform }}
+          labels: ${{ steps.meta.outputs.labels }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          echo "${{ steps.build.outputs.digest }}" > "/tmp/digests/${{ env.PLATFORM_PAIR }}.digest"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: digests-${{ env.PLATFORM_PAIR }}
+          path: /tmp/digests/*
+          retention-days: 1
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-*
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          tags: ${{ github.event.inputs.miko_pbx_version }}
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push manifest
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@%s ' $(cat *.digest))
+
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/docker-compose.yml.sample
+++ b/docker-compose.yml.sample
@@ -1,6 +1,6 @@
 services:
   spotiny:
-    image: spotiny:latest
+    image: ghcr.io/hayabusa58/spotiny:main
     container_name: spotiny
     ports:
       - 3000:3000


### PR DESCRIPTION
この変更により spotiny アプリケーションの Docker イメージが GitHub Actions によってビルドされます。また GitHub Container Registry (ghcr.io) に Docker イメージがアップロードされるようになります。

* 対応プラットフォーム: `linux/amd64`, `linux/arm64`
* イメージの tag はブランチ名がそのまま使われます
* GitHub の Actions runner について、linux/amd64, linux/arm64 ネイティブの runner を使用し並列的にビルド処理が走ります。両方の処理が完了するとマージされて ghcr.io に push されます。
